### PR TITLE
docs: fix typo 'fucntion' -> 'function' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ are "matplotlib" or "plt" for Matplotlib and "plotly" or "ply" for Plotly.
 Every other functionality can be defined during the `plot` function call. These 
 functionalities include the ID column to group the intervals belonging to the same item 
 (transcript, gene, protein...), items disposition, coloring criteria and palette, labels 
-and output form among others. The input for the `plot` fucntion is 1 or more PyRanges 
+and output form among others. The input for the `plot` function is 1 or more PyRanges 
 objects, and the output is by default an interactive plot with zooming options and tooltip 
 information, but if desired the plot can be directly exported to a png or pdf file.
 


### PR DESCRIPTION
Trivial typo fix in the Overview section of `README.md`:

> The input for the `plot` ~~fucntion~~ **function** is 1 or more PyRanges objects ...

No code changes.