### PR TITLE
test(ply): normalize numpy scalars in baseline comparison

### DIFF
--- a/tests/test_ply.py
+++ b/tests/test_ply.py
@@ -19,6 +19,11 @@ def normalize_plotly_json(obj):
         return list(normalize_plotly_json(i) for i in obj)
     elif isinstance(obj, np.ndarray):
         return normalize_plotly_json(obj.tolist())
+    elif isinstance(obj, np.generic):
+        # Coerce numpy scalars (e.g. np.float64, np.int64) to plain Python
+        # types so DeepDiff does not flag them as different from the
+        # JSON-roundtripped baseline values.
+        return obj.item()
     else:
         return obj
 


### PR DESCRIPTION
## Problem

`tests/test_ply.py` is currently red on `main` (21/21 parametrized cases fail in CI), with diffs of the form:

```
- 'y': 0.5,
+ 'y': np.float64(0.5),
```

Under recent numpy 2.x / plotly 6.x, `fig.to_plotly_json()` leaves some scalar values as `numpy.float64` (e.g. annotation `y` coordinates). The on-disk baselines, having been JSON-roundtripped, hold plain Python floats. `DeepDiff(..., ignore_order=True)` then treats the values as type-mismatched and, because of the ignore-order matching strategy, reports entire containing lists as `iterable_item_added` / `iterable_item_removed`, which makes the failure look structural even though it isn't.

## Fix

`normalize_plotly_json` already handles `np.ndarray`. Extend it to also coerce `np.generic` scalars to plain Python via `.item()`. No baseline regeneration needed.

## Verification

Local run on Python 3.12 with numpy 2.4.4, plotly 6.7.0, pyranges1 1.3.8, deepdiff 9.0.0:

```
$ MPLBACKEND=Agg pytest tests/test_ply.py
============================== 21 passed in 3.78s ==============================
$ pytest --mpl tests/test_mpl.py
============================== 18 passed ==============================
$ ruff format --check src
24 files already formatted
```

## Notes

- This is a test-harness-only change; no production code is touched.
- After this lands, follow-up worth considering (separate PR): adding `push` to the CI workflow triggers in `.github/workflows/continuous_integration.yml` so regressions on `main` are surfaced (the last successful run on `main` predates PR #22 because CI only runs on PRs).