### PR TITLE
docs: restore API reference pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,14 +35,9 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx_rtd_theme",
-    "autoapi.extension",
 ]
 autosummary_generate = True  # Enable summary table generation
 
-# AutoAPI settings
-autoapi_type = "python"
-autoapi_dirs = ["../src/pyrangeyes"]  # Adjust the path as necessary
-autoapi_generate_api_docs = False
 
 autodoc_default_options = {
     "members": True,

--- a/docs/prp_options.rst
+++ b/docs/prp_options.rst
@@ -4,7 +4,10 @@ Customizable options
 Functions related to check, set and reset the plot customizable options. For graphical
 explanation check the first figure of the :ref:`Tutorial <tutorial>`.
 
-.. automodule:: pyrangeyes
-    :members:
-    :imported-members:  # Ensure this is set to include imported members
-    :exclude-members: set_engine, get_engine, set_id_col, get_id_col, set_theme, get_theme, set_warnings, get_warnings, plot, register_plot, ncbi_gff, ncbi_vcf, make_scatter
+.. autofunction:: pyrangeyes.print_options
+
+.. autofunction:: pyrangeyes.get_options
+
+.. autofunction:: pyrangeyes.set_options
+
+.. autofunction:: pyrangeyes.reset_options

--- a/docs/prp_plot.rst
+++ b/docs/prp_plot.rst
@@ -3,7 +3,4 @@ Plot function
 
 Pyrangeyes main function.
 
-.. automodule:: pyrangeyes
-    :members:
-    :imported-members:  # Ensure this is set to include imported members
-    :exclude-members: set_engine, get_engine, set_id_col, get_id_col, set_theme, get_theme, set_warnings, get_warnings, register_plot, print_options, set_options, reset_options, ncbi_gff, ncbi_vcf, make_scatter
+.. autofunction:: pyrangeyes.plot

--- a/docs/prp_registerplot.rst
+++ b/docs/prp_registerplot.rst
@@ -3,7 +3,4 @@ Register plot
 
 Register plot function on PyRanges objects.
 
-.. automodule:: pyrangeyes
-    :members:
-    :imported-members:  # Ensure this is set to include imported members
-    :exclude-members: set_engine, get_engine, set_id_col, get_id_col, set_theme, get_theme, set_warnings, get_warnings, plot, print_options, set_options, reset_options, make_scatter, ncbi_gff, ncbi_vcf
+.. autofunction:: pyrangeyes.register_plot

--- a/docs/prp_scatter.rst
+++ b/docs/prp_scatter.rst
@@ -3,7 +3,4 @@ Scatterplot creation
 
 Creates a Scatterplot on PyRanges objects.
 
-.. automodule:: pyrangeyes
-    :members:
-    :imported-members:  # Ensure this is set to include imported members
-    :exclude-members: set_engine, get_engine, set_id_col, get_id_col, set_theme, get_theme,set_warnings, get_warnings, plot, print_options, set_options, reset_options, register_plot, ncbi_gff, ncbi_vcf
+.. autofunction:: pyrangeyes.make_scatter

--- a/docs/prp_settings.rst
+++ b/docs/prp_settings.rst
@@ -5,7 +5,18 @@ Functions to pre set and inspect the variables engine, id_col, theme and warning
 set_engine use is compulsory to obtain the plots, the rest can be specified or not as plot
 parameters.
 
-.. automodule:: pyrangeyes
-    :members:
-    :imported-members:  # Ensure this is set to include imported members
-    :exclude-members: plot, register_plot, print_options, set_options, reset_options, make_scatter, ncbi_gff, ncbi_vcf
+.. autofunction:: pyrangeyes.set_engine
+
+.. autofunction:: pyrangeyes.get_engine
+
+.. autofunction:: pyrangeyes.set_id_col
+
+.. autofunction:: pyrangeyes.get_id_col
+
+.. autofunction:: pyrangeyes.set_theme
+
+.. autofunction:: pyrangeyes.get_theme
+
+.. autofunction:: pyrangeyes.set_warnings
+
+.. autofunction:: pyrangeyes.get_warnings

--- a/docs/prp_vcf.rst
+++ b/docs/prp_vcf.rst
@@ -5,6 +5,8 @@ Functions related to loading, processing, and transforming VCF (Variant Call For
 reading of VCF files into PyRanges objects and flexible manipulation of their fields. For further explanation check the 
 **Dealing with VCF files** section of the :ref:`tutorial <tutorial>`.
 
-.. automodule:: pyrangeyes.vcf
-    :members:
-    :imported-members: 
+.. autofunction:: pyrangeyes.vcf.read_vcf
+
+.. autofunction:: pyrangeyes.vcf.split_fields
+
+.. autofunction:: pyrangeyes.ncbi_vcf

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 pyrangeyes>=0.1.8
+plotly>=5.9.0
 Sphinx==7.3.7
 sphinx-rtd-theme==2.0.0
-sphinx-autoapi==3.0.0
 sphinxcontrib-napoleon==0.7


### PR DESCRIPTION
## Summary
- add Plotly to the ReadTheDocs documentation requirements so importing `pyrangeyes` no longer fails after `browse` became a top-level export
- remove the unused AutoAPI extension from the docs build; it was configured not to generate API docs but still emitted file-read warnings on RTD
- replace brittle `automodule` pages with explicit `autofunction` entries for the public API pages

## Verification
- checked current RTD build log for latest: autodoc failed with `ModuleNotFoundError: No module named 'plotly'`
- compared against older working commit `57731dd`, where `prp_plot.html` generated `id="pyrangeyes.plot"`
- simulated RTD-style clean build from the hotfix worktree: `sphinx-build -b html docs docs/_build/html -W --keep-going` → passed
- confirmed generated HTML contains `pyrangeyes.plot`, options/settings functions, and VCF functions
