### PR TITLE
Add Track.plot convenience method

### DIFF
--- a/src/pyrangeyes/track.py
+++ b/src/pyrangeyes/track.py
@@ -26,3 +26,13 @@ class Track:
     @property
     def name(self):
         return self.options.get("name")
+
+    def plot(self, **kwargs):
+        """Plot this track with :func:`pyrangeyes.plot`.
+
+        Options stored on the track are applied as track-specific options;
+        keyword arguments passed here are forwarded as regular plot options.
+        """
+        from .plot_main import plot
+
+        return plot(self, **kwargs)

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -48,3 +48,21 @@ def test_track_option_overrides_plot_default():
         "packed",
         "unpacked",
     ]
+
+
+def test_track_plot_alias(monkeypatch):
+    calls = []
+
+    def fake_plot(obj, **kwargs):
+        calls.append((obj, kwargs))
+        return "ok"
+
+    import pyrangeyes.plot_main as plot_main
+
+    monkeypatch.setattr(plot_main, "plot", fake_plot)
+
+    track = pe.Track(DATA, name="example")
+    result = track.plot(id_col="transcript_id")
+
+    assert result == "ok"
+    assert calls == [(track, {"id_col": "transcript_id"})]


### PR DESCRIPTION
## Summary
- add `Track.plot(**kwargs)` as a convenience alias for `pyrangeyes.plot(track, **kwargs)`
- cover the alias with a regression test

## Tests
- `.venv/bin/ruff check src tests`
- `.venv/bin/python -m pytest tests/test_track.py -q`
