### PR TITLE
Fix RTD pydata theme dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 pyrangeyes>=0.1.8
 plotly>=5.9.0
 Sphinx==7.3.7
-sphinx-rtd-theme==2.0.0
+pydata-sphinx-theme>=0.16.0
 sphinxcontrib-napoleon==0.7


### PR DESCRIPTION
Read the Docs installs docs/requirements.txt, which still listed sphinx-rtd-theme even though docs/conf.py now uses pydata_sphinx_theme. This adds pydata-sphinx-theme to the RTD docs requirements so the theme can be imported during docs builds.\n\nVerified locally with:\n\n```\n.venv/bin/sphinx-build -q -b html docs docs/_build/html\n```